### PR TITLE
OSX Architectures

### DIFF
--- a/plugin-code/CMakeLists.txt
+++ b/plugin-code/CMakeLists.txt
@@ -52,6 +52,7 @@ option(SCSYNTH "Build plugins for scsynth" ON)
 option(NATIVE "Optimize for native architecture" OFF)
 option(STRICT "Use strict warning flags" OFF)
 option(NOVA_SIMD "Build plugins with nova-simd support." ON)
+option(BUILD_UNIVERSAL "Build a universal binary (ARM and x86_64 architectures)" ON)
 
 ####################################################################################################
 # include libraries

--- a/plugin-code/cmake_modules/SuperColliderServerPlugin.cmake
+++ b/plugin-code/cmake_modules/SuperColliderServerPlugin.cmake
@@ -39,6 +39,10 @@ function(sc_add_server_plugin_properties target is_supernova)
         set_target_properties(${target} PROPERTIES SUFFIX ".scx")
     endif()
 
+    if(APPLE AND BUILD_UNIVERSAL)
+        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+    endif()
+
     target_include_directories(${target} PUBLIC
         ${SC_PATH}/include/plugin_interface
         ${SC_PATH}/include/common


### PR DESCRIPTION
Added option to build universal binary for OSX architectures. Default is ON. This will prevent issues related to users trying to run plugins on ARM and not having a correct build.